### PR TITLE
disclaimer: update wording to match new SBP disclaimer

### DIFF
--- a/common/adoc/common_docinfo_vars.adoc
+++ b/common/adoc/common_docinfo_vars.adoc
@@ -1,3 +1,7 @@
 
-:disclaimer: This article is part of a series of documents called "SUSE Technical Reference Documents". The articles and individual documents published as a SUSE Technical Reference Document were contributed voluntarily by SUSE employees and by third parties. If not stated otherwise inside the document, the articles are intended only to be one example of how a particular action could be taken.  Also, SUSE cannot verify either that the actions described in the articles do what they claim to do or that they do not have unintended consequences. All information found in this article has been compiled with utmost attention to detail. However, this does not guarantee complete accuracy.  Therefore, we need to specifically state that neither SUSE LLC, its affiliates, the authors, nor the translators may be held liable for possible errors or the consequences thereof.
+:disclaimer: Documents published as part of the series SUSE Technical Reference Documents have been contributed voluntarily by SUSE employees and third parties. \
+They are meant to serve as examples of how particular actions can be performed. \
+They have been compiled with utmost attention to detail. However, this does not guarantee complete accuracy. \
+SUSE cannot verify that actions described in these documents do what is claimed or whether actions described have unintended consequences. \
+SUSE LLC, its affiliates, the authors, and the translators may not be held liable for possible errors or the consequences thereof.
 


### PR DESCRIPTION
As discussed earlier today, a wording update for the disclaimer. (The new version is not yet fully propagated on the SBP side.)