### PR TITLE
update default suse cover logo

### DIFF
--- a/common/bin/gssetup.sh
+++ b/common/bin/gssetup.sh
@@ -218,8 +218,8 @@ sed -i "s/MAIN=\"gs_suseprod_partner-partnerprod.adoc\"/MAIN=\"${documentbase}.a
 [ -d media/src/svg ] || mkdir -p media/src/svg
 #cd media/src/svg
 # create symlink to logo
-[ -L media/src/svg/suse-white-logo-green.svg ] || \
-  ln -s ../../../../../../common/images/src/svg/suse-white-logo-green.svg media/src/svg/
+[ -L media/src/svg/suse.svg ] || \
+  ln -s ../../../../../../common/images/src/svg/suse.svg media/src/svg/
 #cd ../../..
 # create images symlink
 [ -L images ] || \

--- a/common/templates/start/_docinfo-file
+++ b/common/templates/start/_docinfo-file
@@ -64,7 +64,7 @@
 <cover role="logos">
   <mediaobject>
     <imageobject>
-      <imagedata fileref="suse-white-logo-green.svg" width="4em"/>
+      <imagedata fileref="suse.svg" width="4em"/>
     </imageobject>
   </mediaobject>
 </cover>


### PR DESCRIPTION
Update getting started templates and gssetup.sh script to use common/images/src/svg/suse.svg as the default cover logo image
