### PR TITLE
trd kr ssng

### DIFF
--- a/common/adoc/common_trd_legal_notice.adoc
+++ b/common/adoc/common_trd_legal_notice.adoc
@@ -1,4 +1,4 @@
-Copyright (C) 2006–2022 SUSE LLC and contributors. All rights reserved. 
+Copyright (C) 2006–2023 SUSE LLC and contributors. All rights reserved. 
 
 Permission is granted to copy, distribute and/or modify this document under the terms of
 the GNU Free Documentation License, Version 1.2 or (at your option) version 1.3; with the

--- a/kubernetes/reference/DC-kubernetes_rc_k3s-slemicro_ampere-altra
+++ b/kubernetes/reference/DC-kubernetes_rc_k3s-slemicro_ampere-altra
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_k3s-slemicro_cisco-c240-sd
+++ b/kubernetes/reference/DC-kubernetes_rc_k3s-slemicro_cisco-c240-sd
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_k3s-slemicro_dell-poweredge
+++ b/kubernetes/reference/DC-kubernetes_rc_k3s-slemicro_dell-poweredge
@@ -1,6 +1,6 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
+ROLE="trd"
 PROFROLE="sbp"
 
 ## -------------------------------
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_k3s-slemicro_hpe-proliant-synergy
+++ b/kubernetes/reference/DC-kubernetes_rc_k3s-slemicro_hpe-proliant-synergy
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_k3s-slemicro_hpq-zcentral4r
+++ b/kubernetes/reference/DC-kubernetes_rc_k3s-slemicro_hpq-zcentral4r
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_k3s-slemicro_lnvgy-se350-se450
+++ b/kubernetes/reference/DC-kubernetes_rc_k3s-slemicro_lnvgy-se350-se450
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_k3s-slemicro_smci-superserver
+++ b/kubernetes/reference/DC-kubernetes_rc_k3s-slemicro_smci-superserver
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_k3s-sles_ampere-altra
+++ b/kubernetes/reference/DC-kubernetes_rc_k3s-sles_ampere-altra
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_k3s-sles_cisco-c240-sd
+++ b/kubernetes/reference/DC-kubernetes_rc_k3s-sles_cisco-c240-sd
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_k3s-sles_dell-poweredge
+++ b/kubernetes/reference/DC-kubernetes_rc_k3s-sles_dell-poweredge
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_k3s-sles_hpe-proliant-synergy
+++ b/kubernetes/reference/DC-kubernetes_rc_k3s-sles_hpe-proliant-synergy
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_k3s-sles_hpq-zcentral4r
+++ b/kubernetes/reference/DC-kubernetes_rc_k3s-sles_hpq-zcentral4r
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_k3s-sles_lnvgy-se350-se450
+++ b/kubernetes/reference/DC-kubernetes_rc_k3s-sles_lnvgy-se350-se450
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_k3s-sles_smci-superserver
+++ b/kubernetes/reference/DC-kubernetes_rc_k3s-sles_smci-superserver
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_rancher-k3s-slemicro_cisco-c240-sd
+++ b/kubernetes/reference/DC-kubernetes_rc_rancher-k3s-slemicro_cisco-c240-sd
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_rancher-k3s-slemicro_dell-poweredge
+++ b/kubernetes/reference/DC-kubernetes_rc_rancher-k3s-slemicro_dell-poweredge
@@ -1,6 +1,6 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
+ROLE="trd"
 PROFROLE="sbp"
 
 ## -------------------------------
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_rancher-k3s-slemicro_hpe-proliant-synergy
+++ b/kubernetes/reference/DC-kubernetes_rc_rancher-k3s-slemicro_hpe-proliant-synergy
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_rancher-k3s-slemicro_hpq-zcentral4r
+++ b/kubernetes/reference/DC-kubernetes_rc_rancher-k3s-slemicro_hpq-zcentral4r
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_rancher-k3s-slemicro_smci-superserver
+++ b/kubernetes/reference/DC-kubernetes_rc_rancher-k3s-slemicro_smci-superserver
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_rancher-k3s-sles_cisco-c240-sd
+++ b/kubernetes/reference/DC-kubernetes_rc_rancher-k3s-sles_cisco-c240-sd
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_rancher-k3s-sles_dell-poweredge
+++ b/kubernetes/reference/DC-kubernetes_rc_rancher-k3s-sles_dell-poweredge
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_rancher-k3s-sles_hpe-proliant-synergy
+++ b/kubernetes/reference/DC-kubernetes_rc_rancher-k3s-sles_hpe-proliant-synergy
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_rancher-k3s-sles_hpq-zcentral4r
+++ b/kubernetes/reference/DC-kubernetes_rc_rancher-k3s-sles_hpq-zcentral4r
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_rancher-k3s-sles_smci-superserver
+++ b/kubernetes/reference/DC-kubernetes_rc_rancher-k3s-sles_smci-superserver
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_rke1-sles_ampere-altra
+++ b/kubernetes/reference/DC-kubernetes_rc_rke1-sles_ampere-altra
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_rke1-sles_cisco-c240-sd
+++ b/kubernetes/reference/DC-kubernetes_rc_rke1-sles_cisco-c240-sd
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_rke1-sles_dell-poweredge
+++ b/kubernetes/reference/DC-kubernetes_rc_rke1-sles_dell-poweredge
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_rke1-sles_hpe-proliant-synergy
+++ b/kubernetes/reference/DC-kubernetes_rc_rke1-sles_hpe-proliant-synergy
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_rke1-sles_hpq-zcentral4r
+++ b/kubernetes/reference/DC-kubernetes_rc_rke1-sles_hpq-zcentral4r
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_rke1-sles_smci-superserver
+++ b/kubernetes/reference/DC-kubernetes_rc_rke1-sles_smci-superserver
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_rke2-sles_cisco-c240-sd
+++ b/kubernetes/reference/DC-kubernetes_rc_rke2-sles_cisco-c240-sd
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_rke2-sles_dell-poweredge
+++ b/kubernetes/reference/DC-kubernetes_rc_rke2-sles_dell-poweredge
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_rke2-sles_hpe-proliant-synergy
+++ b/kubernetes/reference/DC-kubernetes_rc_rke2-sles_hpe-proliant-synergy
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_rke2-sles_hpq-zcentral4r
+++ b/kubernetes/reference/DC-kubernetes_rc_rke2-sles_hpq-zcentral4r
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_rc_rke2-sles_smci-superserver
+++ b/kubernetes/reference/DC-kubernetes_rc_rke2-sles_smci-superserver
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_ri_k3s-slemicro
+++ b/kubernetes/reference/DC-kubernetes_ri_k3s-slemicro
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_ri_k3s-sles
+++ b/kubernetes/reference/DC-kubernetes_ri_k3s-sles
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_ri_rancher-k3s-slemicro
+++ b/kubernetes/reference/DC-kubernetes_ri_rancher-k3s-slemicro
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_ri_rancher-k3s-sles
+++ b/kubernetes/reference/DC-kubernetes_ri_rancher-k3s-sles
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_ri_rke1-sles
+++ b/kubernetes/reference/DC-kubernetes_ri_rke1-sles
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/DC-kubernetes_ri_rke2-sles
+++ b/kubernetes/reference/DC-kubernetes_ri_rke2-sles
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 #DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/TRD-kubernetes_reference
+++ b/kubernetes/reference/TRD-kubernetes_reference
@@ -1,7 +1,7 @@
 # uncomment DRAFT until content is completed/validated/ready for submission
 DRAFT=yes
-ROLE="sbp"
-PROFROLE="sbp"
+ROLE="trd"
+#PROFROLE="sbp"
 
 ## -------------------------------
 ## Doc Config File for DAPS
@@ -15,14 +15,14 @@ PROFROLE="sbp"
 # Main Document 
 MAIN="SA.adoc"
 # Stylesheet Root
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/trd"
 # Format Type
 ADOC_TYPE="book"
 # Turn on postprocessing
 ADOC_POST="yes"
 # Leverage SUSE Best Practices
 XSLTPARAM="--stringparam publishing.series=sbp"
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 # Enable attributes
 ADOC_ATTRIBUTES=" --attribute env-daps=1"
 

--- a/kubernetes/reference/adoc/SA_vars.adoc
+++ b/kubernetes/reference/adoc/SA_vars.adoc
@@ -32,7 +32,7 @@ endif::RC[]
 ifdef::RI[]
 :title: Introductory Deployment
 :type: Reference Implementation
-// :subtitle: 
+:subtitle: Basic Steps
 endif::RI[]
 
 ifdef::GS[]

--- a/kubernetes/reference/adoc/SA_vars.adoc
+++ b/kubernetes/reference/adoc/SA_vars.adoc
@@ -1,3 +1,4 @@
+:trd: Technical Reference Documentation
 
 :companyName: SUSE
 :portfolioName: Rancher
@@ -25,17 +26,19 @@ ifdef::RA,RC,RI,GS[]
 
 ifdef::RC[]
 :title: Layered Stack Deployment
-:subtitle: Reference Configuration
+:type: Reference Configuration
 endif::RC[]
 
 ifdef::RI[]
 :title: Introductory Deployment
-:subtitle: Reference Implementation
+:type: Reference Implementation
+// :subtitle: 
 endif::RI[]
 
 ifdef::GS[]
 :title: Tutorial Instance
-:subtitle: Getting Started
+:type: Getting Started
+// :subtitle: 
 endif::GS[]
 
 ifdef::focusRancher[]
@@ -78,7 +81,7 @@ ifdef::layerSLES[:productname: {pn_SLES} {pn_SLES_Version}, {productname}]
 endif::RA,RC,RI,GS[]
 
 ifdef::RC[]
-:subtitle: Reference Configuration : Integrated with
+:subtitle: Integrated with
 ifdef::iIHV[]
 ifdef::IHV-Ampere[:subtitle: {subtitle} {an_Ampere} (R) {familyAmpere-Altra} (R)]
 ifdef::IHV-Cisco[:subtitle: {subtitle} {vn_Cisco} (R)]

--- a/kubernetes/reference/adoc/docinfo.xml
+++ b/kubernetes/reference/adoc/docinfo.xml
@@ -1,27 +1,74 @@
-<!-- https://tdg.docbook.org/tdg/5.1/info -->
+<!-- https://tdg.docbook.org/tdg/5.2/info -->
 
 <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-    <dm:bugtracker>
-	<dm:url>https://github.com/SUSE/technical-reference-documentation/issues/new</dm:url>
-        <dm:product>Kubernetes</dm:product>
-    </dm:bugtracker>
-    <dm:editurl>https://github.com/SUSE/technical-reference-documentation/edit/master/adoc/</dm:editurl>
+  <dm:bugtracker>
+    <dm:url>https://github.com/SUSE/technical-reference-documentation/issues/new</dm:url>
+    <!--  <dm:product>{title}</dm:product> -->
+  </dm:bugtracker>
 </dm:docmanager>
 
-<!--<title>{title}</title>-->
+<!-- Note to author/editor
+     Attributes used here (enclosed in curly braces).
+     General variables are defined in common_docinfo_vars.adoc.
+     Variable specific to this document (such as the title) are
+     defined with the main content in the adoc or SA_vars.adoc file(s).
+     See comments below for additional options.
+-->
+
+<!-- document organization metadata
+     Do NOT modify this section
+     <orgname>Technical Reference Documentation</orgname>
+-->
+<meta name="series">{trd}</meta>
+<meta name="type">{type}</meta>
+
+<!-- document title and subtitle -->
+<!-- <title>{title}</title> -->
 <subtitle>{subtitle}</subtitle>
-<!--<orgname>Best Practices / Technical Reference Documentation</orgname>-->
+
+<!-- platform and product metadata
+     Replicate for additional platforms.
+     Define platform2, etc. in adoc file.
+-->
 <productname>{productname}</productname>
 
+<!-- author metadata (mostly skipped in kubernetes/reference)
+     Replicate author tag structure inside this authorgroup
+     for additional authors.
+     Use editor and othercredit tag groups for additional contributors.
+     Update variables in adoc file.
+-->
+<!-- <authorgroup> -->
+  <!-- <author> -->
+    <!-- <personname> -->
+      <!-- <firstname></firstname> -->
+      <!-- <surname></surname> -->
+    <!-- </personname> -->
+    <!-- <affiliation> -->
+      <!-- <jobtitle></jobtitle> -->
+      <!-- <orgname></orgname> -->
+    <!-- </affiliation> -->
+  <!-- </author> -->
+<!-- </authorgroup> -->
+
+<!-- logo images
+     Duplicate mediaobject tag group and
+     reference additional logos as needed.
+     Place logo files under media directory tree.
+-->
 <cover role="logos">
-    <mediaobject>
-        <imageobject>
-            <imagedata fileref="suse.svg"/>
-        </imageobject>
-    </mediaobject>
+  <mediaobject>
+    <imageobject>
+      <imagedata fileref="suse.svg" width="4em"/>
+    </imageobject>
+  </mediaobject>
 </cover>
 
+<!-- brief abstract/disclaimer for document
+     Update with an enticing summary.
+-->
 <abstract>
-    <para>{preface}</para>
-    <para> <emphasis role="strong">Disclaimer:</emphasis>  {disclaimer} </para>
+  <para>{preface}</para>
+  <para> <emphasis role="strong">Disclaimer:</emphasis> {disclaimer} </para>
 </abstract>
+

--- a/kubernetes/reference/adoc/docinfo.xml
+++ b/kubernetes/reference/adoc/docinfo.xml
@@ -38,18 +38,18 @@
      Use editor and othercredit tag groups for additional contributors.
      Update variables in adoc file.
 -->
-<!-- <authorgroup> -->
-  <!-- <author> -->
-    <!-- <personname> -->
-      <!-- <firstname></firstname> -->
-      <!-- <surname></surname> -->
-    <!-- </personname> -->
-    <!-- <affiliation> -->
-      <!-- <jobtitle></jobtitle> -->
-      <!-- <orgname></orgname> -->
-    <!-- </affiliation> -->
-  <!-- </author> -->
-<!-- </authorgroup> -->
+<!-- <authorgroup>
+  <author>
+    <personname>
+      <firstname></firstname>
+      <surname></surname>
+    </personname>
+    <affiliation>
+      <jobtitle></jobtitle>
+      <orgname></orgname>
+    </affiliation>
+  </author>
+</authorgroup> -->
 
 <!-- logo images
      Duplicate mediaobject tag group and


### PR DESCRIPTION
Updates of all TRD/kubernetes/reference RI/RC docs to leverage DocBook 5.2 and the new TRD stylesheets, including
- DC template
- all existing DC files for current published docs
- the few leveraged general files
- plus updated common_trd_legal_notice for the new calendar year

After the successful workflow runs and the review, feel free to merge this branch into main, and publish the 42 TRD RI/RC documents (as there isn't much change in their content, since just leveraging the docbook/stylesheet changes with the branch/PR)