### PR TITLE
Include subtitle in document title

### DIFF
--- a/linux/start/ibm/adoc/gs_sles_ibm-hpvs.adoc
+++ b/linux/start/ibm/adoc/gs_sles_ibm-hpvs.adoc
@@ -43,8 +43,9 @@ include::./common_docinfo_vars.adoc[]
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // document
 // -
-:title: Confidential Computing with SUSE Linux Enterprise Base Container Images
-:subtitle: Using the IBM Hyper Protect Platform
+:title: Confidential Computing with SUSE Linux Enterprise Base Container Images Using the IBM Hyper Protect Platform
+// :subtitle: Using the IBM Hyper Protect Platform
+:subtitle:
 
 :product1: SLE BCI
 :product1_full: SUSE Linux Enterprise Base Container Images


### PR DESCRIPTION
@chabowski @tlssuse This change is because the subtitle is not included in the TRD text that links to the documentation on suse.com.