### PR TITLE
change techpartner from 'Project Jypyter' to 'Jupyter'

### DIFF
--- a/linux/start/jupyter/adoc/gs_sles_jupyter-jupyterlab_container-vars.adoc
+++ b/linux/start/jupyter/adoc/gs_sles_jupyter-jupyterlab_container-vars.adoc
@@ -95,7 +95,7 @@
 :comp2-docs: https://documentation.suse.com/container/all/single-html/Container-guide
 :comp2-registry: https://registry.suse.com
 
-:comp3-provider: Project Jupyter
+:comp3-provider: Jupyter
 :comp3: JupyterLab
 :comp3-full: JupyterLab
 :comp3-version1: 4.2.5


### PR DESCRIPTION
Changing component provider name to match existing SUSE Docs JSON metadata.