### PR TITLE
update file content needed for metadata context

### DIFF
--- a/kubernetes/reference/adoc/SA.adoc
+++ b/kubernetes/reference/adoc/SA.adoc
@@ -1,9 +1,9 @@
 :docinfo: shared
 include::./common_docinfo_vars.adoc[]
-
 include::./SA_vars.adoc[]
+[#art-{article-id}]
 
-= {title}
+= {title} : {subtitle}
 
 // About (not used yet)
 // include::./SA-About.adoc[]

--- a/kubernetes/reference/adoc/SA_vars.adoc
+++ b/kubernetes/reference/adoc/SA_vars.adoc
@@ -1,11 +1,37 @@
+// adjust 
+:revision-date: 2Oct2024
+:style: trd
+:article-id: enterprise-container-management
+:rev2-description: Metadata update
+:rev2-date: 2024-10-18
+:comp3-full: 
+:comp3-version1:
+
+// General
+// - targeted metadata variables just begin with "m"
+
 :trd: Technical Reference Documentation
 
 :companyName: SUSE
 :portfolioName: Rancher
 :logo: suse.svg
 
+:mSeries: Technical Reference Documentation
+
+// beginning word type
+:mType: Reference
+
+// :subtitle: configured below in various spaces
+
+// covering the various kubernetes/reference documents
+ifdef::RA,RC,RI[]
+
+:mDescription: Enterprise Kubernetes 
+:mSocialDescr: (<55 characters) social media description
+
 :useCase: Enterprise Kubernetes
 
+// Include more variable files
 include::./CSP/SA_vars.adoc[]
 include::./IHV/SA_vars.adoc[]
 include::./ISV/SA_vars.adoc[]
@@ -16,129 +42,233 @@ ifdef::iSLEMicro[include::SUSE/SLE-Micro/SA_vars.adoc[]]
 ifdef::iSLES[include::SUSE/SLES/SA_vars.adoc[]]
 ifdef::iSUMa[include::SUSE/SUMa/SA_vars.adoc[]]
 
-ifdef::iHarvester[include::SUSE/Harvester/SA_vars.adoc[]]
-ifdef::iLonghorn[include::SUSE/Longhorn/SA_vars.adoc[]]
+ifdef::iNeuVector[include::SUSE/NeuVector/SA_vars.adoc[]]
 ifdef::iRancher[include::SUSE/Rancher/SA_vars.adoc[]]
 ifdef::iRKE1[include::SUSE/RKE1/SA_vars.adoc[]]
 ifdef::iRKE2[include::SUSE/RKE2/SA_vars.adoc[]]
 ifdef::iK3s[include::SUSE/K3s/SA_vars.adoc[]]
+ifdef::iLonghorn[include::SUSE/Longhorn/SA_vars.adoc[]]
+ifdef::iHarvester[include::SUSE/Harvester/SA_vars.adoc[]]
 
-ifdef::RA,RC,RI,GS[]
+// Augment for various document types
+ifdef::RA,RC,RI[]
 
+// Reference Configuration
 ifdef::RC[]
 :title: Layered Stack Deployment
-:type: Reference Configuration
+:subtitle: Integrated with
+:mType: {mType} Configuration
 endif::RC[]
 
+// Reference Implementation
 ifdef::RI[]
 :title: Introductory Deployment
-:type: Reference Implementation
 :subtitle: Basic Steps
+:mType: {mType} Implementation
+:mTechPartner: SUSE
+:rev1-date: 2022-03-28
+:rev1-description: Original contribution
 endif::RI[]
 
-ifdef::GS[]
-:title: Tutorial Instance
-:type: Getting Started
-// :subtitle: 
-endif::GS[]
-
+// Targeting Rancher
 ifdef::focusRancher[]
-:productname: {pn_Rancher} {pn_Rancher_Version}
+:mProductList: {pn_Rancher} {pn_Rancher_Version}
+:productname: {pn_Rancher}
+:mDescription: {mDescription} Management
+:comp1-full: {pn_Rancher}
+:comp1-version1: {pn_Rancher_Version}
+
 ifdef::RC[]
+
 :title: {title} of {pn_Rancher}
-ifdef::layerK3s[:productname: {pn_K3s} {pn_K3s_Version}, {productname}]
-ifdef::layerRKE1[:productname: {pn_RKE1} {pn_RKE1_Version}, {productname}]
-ifdef::layerRKE2[:productname: {pn_RKE2} {pn_RKE2_Version}, {productname}]
+
+// Various Layers
+ifdef::layerK3s[]
+:mProductList: {mProductList}, {pn_K3s} {pn_K3s_Version}
+:productname: {pn_K3s}, {productname}
+:mDescription: {mDescription} Lightweight IoT and Edge Distribution
+:comp2-full: {pn_K3s}
+:comp2-version1: {pn_K3s_Version}
+endif::layerK3s[]
+
+ifdef::layerRKE1[]
+:mProductList: {mProductList}, {pn_RKE1} {pn_RKE1_Version}
+:productname: {pn_RKE1}, {productname}
+:mDescription: {mDescription} Distribution
+:comp2-full: {pn_RKE1}
+:comp2-version1: {pn_RKE1_Version}
+endif::layerRKE1[]
+
+ifdef::layerRKE2[]
+:mProductList: {mProductList}, {pn_RKE2} {pn_RKE2_Version}
+:productname: {pn_RKE2}, {productname}
+:mDescription: Secure {mDescription} Distribution
+:comp2-full: {pn_RKE2}
+:comp2-version1: {pn_RKE2_Version}
+endif::layerRKE2[]
+
 endif::RC[]
+
 ifdef::RI[]
+
 :title: {title} of {pn_Rancher}
-ifdef::layerK3s[:productname: {pn_K3s} {pn_K3s_Version}, {productname}]
-ifdef::layerRKE1[:productname: {pn_RKE1} {pn_RKE1_Version}, {productname}]
-ifdef::layerRKE2[:productname: {pn_RKE2} {pn_RKE2_Version}, {productname}]
+
+ifdef::layerK3s[]
+:mProductList: {mProductList}, {pn_K3s} {pn_K3s_Version}
+:productname: {pn_K3s}, {productname}
+:mDescription: {mDescription} Lightweight IoT and Edge Distribution
+:layerK3s[:comp2-full: {pn_K3s}
+:layerK3s[:comp2-version1: {pn_K3s_Version}
+endif::layerK3s[]
+
+ifdef::layerRKE1[]
+:mProductList: {mProductList}, {pn_RKE1} {productname}
+:productname: {pn_RKE1} {pn_RKE1_Version}, {productname}
+:mDescription: {mDescription} Distribution
+:comp2-full: {pn_RKE1}
+:layerRKE1[:comp2-version1: {pn_RKE1_Version}
+endif::layerRKE1[]
+
+ifdef::layerRKE2[]
+:mProductList: {mProductList}, {pn_RKE2} {pn_RKE2_Version}
+:productname: {pn_RKE2}, {productname}
+:mDescription: Secure {mDescription} Distribution
+:comp2-full: {pn_RKE2}
+:comp2-version1: {pn_RKE2_Version}
+endif::layerRKE2[]
+
 endif::RI[]
-ifdef::GS[]
-:title: {title} of {pn_Rancher}
-endif::GS[]
 endif::focusRancher[]
 
+// Focusing on other Kubernetes products
 ifdef::focusK3s[]
-:productname: {pn_K3s} {pn_K3s_Version}
+:mProductList: {pn_K3s} {pn_K3s_Version}
+:productname: {pn_K3s}
+:mDescription: {mDescription} Lightweight IoT and Edge Distribution
+:comp1-full: {pn_K3s}
+:comp1-version1: {pn_K3s_Version}
 :title: {title} of {pn_K3s}
 endif::focusK3s[]
 
 ifdef::focusRKE1[]
-:productname: {pn_RKE1} {pn_RKE1_Version}
+:mProductList: {pn_RKE1} {pn_RKE1_Version}
+:productname: {pn_RKE1}
+:mDescription: {mDescription} Distribution
+:comp1-full: {pn_RKE1}
+:comp1-version1: {pn_RKE1_Version}
 :title: {title} of {pn_RKE1}
 endif::focusRKE1[]
 
 ifdef::focusRKE2[]
-:productname: {pn_RKE2} {pn_RKE2_Version}
+:mProductList: {pn_RKE2} {pn_RKE2_Version}
+:productname: {pn_RKE2}
+:mDescription: Secure {mDescription} Distribution
+:comp1-full: {pn_RKE2}
+:comp1-version1: {pn_RKE2_Version}
 :title: {title} of {pn_RKE2}
 endif::focusRKE2[]
 
-ifdef::layerSLEMicro[:productname: {pn_SLEMicro} {pn_SLEMicro_Version}, {productname}]
-ifdef::layerSLES[:productname: {pn_SLES} {pn_SLES_Version}, {productname}]
+// Focusing on other Linux products
+ifdef::layerSLEMicro[]
+:mProductList: {mProductList}, {pn_SLEMicro} {pn_SLEMicro_Version}
+:productname: {pn_SLEMicro}
+:mDescription: Ultra-reliable, immutable Linux operating system
+ifdef::focusRancher[]
+:comp3-full: {pn_SLEMicro}
+:comp3-version1: {pn_SLEMicro_Version}
+endif::focusRancher[]
+ifndef::focusRancher[]
+:comp2-full: {pn_SLEMicro}
+:comp2-version1: {pn_SLEMicro_Version}
+endif::focusRancher[]
+endif::layerSLEMicro[]
 
-endif::RA,RC,RI,GS[]
+ifdef::layerSLES[]
+:mProductList: {mProductList}, {pn_SLES} {pn_SLES_Version}
+:productname: {pn_SLES}
+:mDescription: The platform for your business-critical apps in any environment
+ifdef::focusRancher[]
+:comp3-full: {pn_SLES}
+:comp3-version1: {pn_SLES_Version}
+endif::focusRancher[]
+ifndef::focusRancher[]
+:comp2-full: {pn_SLES}
+:comp2-version1: {pn_SLES_Version}
+endif::focusRancher[]
+endif::layerSLES[]
 
+endif::RA,RC,RI[]
+
+// Including IHV Partner Layers
 ifdef::RC[]
-:subtitle: Integrated with
+
 ifdef::iIHV[]
 ifdef::IHV-Ampere[]
 :subtitle: {subtitle} {an_Ampere} (R) {familyAmpere-Altra} (R)
 :logo: {companyName}-{an_Ampere}.svg
+:mTechPartner: {an_Ampere}
+:rev1-date: 2023-08-29
+:rev1-description: Original contribution
 endif::IHV-Ampere[]
 ifdef::IHV-Cisco[]
 :subtitle: {subtitle} {vn_Cisco} (R)
 :logo: {companyName}-{vn_Cisco}.svg
+:mTechPartner: {vn_Cisco}
+:rev1-date: 2023-12-18
+:rev1-description: Original contribution
 endif::IHV-Cisco[]
 ifdef::IHV-Dell[]
 :subtitle: {subtitle} {vn_Dell} (R)
 :logo: {companyName}-{an_Dell}.svg
+:mTechPartner: {vn_Dell}
+:rev1-date: 2022-03-28
+:rev1-description: Original contribution
 endif::IHV-Dell[]
 ifdef::IHV-Fujitsu[]
 :subtitle: {subtitle} {vn_Fujitsu} (R)
 :logo: {companyName}-{an_Fujitsu}.svg
+:mTechPartner: {vn_Fujitsu}
 endif::IHV-Fujitsu[]
 ifdef::IHV-HPE[]
 :subtitle: {subtitle} {vn_HPE} (R)
 :logo: {companyName}-{an_HPE}.svg
+:mTechPartner: {vn_HPE}
+:rev1-date: 2022-04-06
+:rev1-description: Original contribution
 endif::IHV-HPE[]
 ifdef::IHV-HPQ[]
 :subtitle: {subtitle} {vn_HPQ} (R)
 :logo: {companyName}-{vn_HPQ}.svg
+:mTechPartner: {vn_HPQ}
+:rev1-date: 2022-09-15
+:rev1-description: Original contribution
 endif::IHV-HPQ[]
 ifdef::IHV-IBM[]
 :subtitle: {subtitle} {vn_IBM} (R)
 :logo: {companyName}-{an_IBM}.svg
+:mTechPartner: {vn_IBM}
 endif::IHV-IBM[]
 ifdef::IHV-LNVGY[]
 :subtitle: {subtitle} {vn_LNVGY} (R)
 :logo: {companyName}-{vn_LNVGY}.svg
+:mTechPartner: {vn_LNVGY}
+:rev1-date: 2022-12-22
+:rev1-description: Original contribution
 endif::IHV-LNVGY[]
 ifdef::IHV-SMCi[]
 :subtitle: {subtitle} {vn_SMCi} (R)
 :logo: {companyName}-{vn_SMCi}.svg
+:mTechPartner: {vn_SMCi}
+:rev1-date: 2022-03-28
+:rev1-description: Original contribution
 endif::IHV-SMCi[]
+
 endif::iIHV[]
 endif::RC[]
 
-////
-:author: TBD
-:authorEmail: TBD
-////
+// :preface: content with :disclaimer: in common_docinfo_vars.adoc
 
-:authorGHURL: https://github.com/SUSE/technical-reference-documentation
-
-:imagesdir: ../media/
-
-ifdef::env-github[]
-:imagesdir: {authorGHURL}/blob/main/media/
-endif::env-github[]
-
-
-ifdef::RA,RC,RI,GS[]
-
+ifdef::RA,RC,RI[]
 :preface: The purpose of this document is to provide an overview and procedure of implementing {companyName} (R)
 ifdef::iCSP,iIHV,iISV[:preface: {preface} and partner]
 :preface: {preface} offerings for
@@ -154,6 +284,18 @@ endif::focusRKE1[]
 ifdef::focusRKE2[]
 :preface: {preface} {pn_RKE2} ({an_RKE2}), a Kubernetes distribution that runs entirely within containers on bare-metal and virtualized nodes. {an_RKE2} solves the problem of installation complexity and the operation is both simplified and easily automated, while entirely accommodating the operating system and platform it is running on. Also being a hardened, FIPS-enabled version, it adopts a compliance-based approach toward security, targeting standard risk management frameworks and best practices with the goal of stronger defense for cloud-native applications.
 endif::focusRKE2[]
+endif::RA,RC,RI[]
 
-endif::RA,RC,RI,GS[]
+////
+:author: TBD
+:authorEmail: TBD
+////
+
+:authorGHURL: https://github.com/SUSE/technical-reference-documentation
+
+:imagesdir: ../media/
+
+ifdef::env-github[]
+:imagesdir: {authorGHURL}/blob/main/media/
+endif::env-github[]
 

--- a/kubernetes/reference/adoc/docinfo.xml
+++ b/kubernetes/reference/adoc/docinfo.xml
@@ -1,44 +1,149 @@
 <!-- https://tdg.docbook.org/tdg/5.2/info -->
 
+
+<!-- ## DocManager ##
+        - direct GitHub link to report issues or request more information -->
 <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
   <dm:bugtracker>
     <dm:url>https://github.com/SUSE/technical-reference-documentation/issues/new</dm:url>
-    <!--  <dm:product>{title}</dm:product> -->
+    <dm:product>{title}</dm:product>
   </dm:bugtracker>
 </dm:docmanager>
 
 <!-- Note to author/editor
-     Attributes used here (enclosed in curly braces).
-     General variables are defined in common_docinfo_vars.adoc.
-     Variable specific to this document (such as the title) are
-     defined with the main content in the adoc or SA_vars.adoc file(s).
-     See comments below for additional options.
--->
+     - This docinfo XML file
+       - includes and uses ... to minimize the need for edits
+	 - core values/attributes (some are also utilized for metadata)
+	 - metadata inclusion that helps identify the content of the document
+	- leverages attributes/variables
+	  - referenced here with curly braces, ( e.g. {title} )
+	  - such variables are defined
+	    - generally in common_docinfo_vars.adoc
+	    - specific ones can be in 
+	      - the main adoc content or
+	      - in various included SA_vars.adoc file(s)
+     - Find more details on attribute/variables in var file comments and in
+       https://github.com/SUSE/technical-reference-documentation/blob/main/common/templates/start/README.md -->
 
-<!-- document organization metadata
-     Do NOT modify this section
-     <orgname>Technical Reference Documentation</orgname>
--->
-<meta name="series">{trd}</meta>
-<meta name="type">{type}</meta>
 
-<!-- document title and subtitle -->
+<!-- ######################################################################
+     ################### DOCUMENT VALUES / ATTRIBUTES #####################
+     ###################################################################### -->
+
+
+<!-- ## Series ##
+        - determines which tab on the doc home page this is associated with
+          NOTE: default value is in SA_vars.adoc -->
+<meta name="series">{mSeries}</meta>
+
+
+<!-- ## Type ##
+        - filter for the different document types
+          NOTE: value(s) are in SA_vars.adoc
+	        and are layered upon variable spaces -->
+<meta name="type">{mType}</meta>
+
+
+<!-- ## Document title / subtitle ##
+        - title is not included here
+        - element is used for search and social media purposes
+        - length is strictly limited to 55 characters
+          NOTE: value(s) are in SA_vars.adoc
+                and are layered upon further variable spaces -->
 <!-- <title>{title}</title> -->
 <subtitle>{subtitle}</subtitle>
 
-<!-- platform and product metadata
-     Replicate for additional platforms.
-     Define platform2, etc. in adoc file.
--->
-<productname>{productname}</productname>
+<!-- ## Brief abstract for document ##
+        - update with an enticing summary in SA_vars.adoc
+- augmented with {disclaimer} from common_docinfo_vars.adoc -->
+<abstract>
+  <para>{preface}</para>
+  <para> <emphasis role="strong">Disclaimer:</emphasis> {disclaimer} </para>
+</abstract>
 
-<!-- author metadata (mostly skipped in kubernetes/reference)
-     Replicate author tag structure inside this authorgroup
-     for additional authors.
-     Use editor and othercredit tag groups for additional contributors.
-     Update variables in adoc file.
+<!-- ## Description ##
+        - displayed on a search engine results page
+        - the character limit is at 150
+          NOTE: value(s) are in SA_vars.adoc
+                and are layered upon variable spaces -->
+<meta name="description">{mDescription}</meta>
+
+
+<!-- # FIXME : still work in progress, since not done in RI/RC -->
+<!-- ## Social media description ##
+        - displayed whenever a document of ours is shared on X or Facebook
+        - character limit is at 55
+          NOTE: unused value noted in SA_vars.adoc -->
+<meta name="social-descr">{mSocialDescr}</meta>
+
+
+<!-- ## Category (not applicable to TRDs) ## -->
+
+
+<!-- ## Task ##
+        - filter by task tab on the index page -->
+<meta name="task">
+  <phrase>Container Management</phrase>
+  <phrase>Deployment</phrase>
+  <phrase>Clustering</phrase>
+</meta>
+
+
+<!-- ## Productname & Version ##
+        - tells Google and friends what product and version a piece applies to
+        - all the products named in these tags should be SUSE products only
+          NOTE: value(s) are in SA_vars.adoc
+                and are layered upon variable spaces -->
+<meta name="productname">
+  <productname version="{comp1-version1}">{comp1-full}</productname>
+  <productname version="{comp2-version1}">{comp2-full}</productname>
+  <productname version="{comp3-version1}">{comp3-full}</productname>
+</meta>
+
+
+<!-- FIXME : deprecated -->
+<!-- ## Platform ##
+        - Identifies the primary SUSE component in a more text-friendly way.
+     For now, use the full component name and supported versions.
+     E.g., "SUSE Linux Enterprise Server for SAP Applications 12 and 15"
+     NOTE: This metadata tag will be deprecated in the next template release.
 -->
-<!-- <authorgroup>
+<!-- <meta name="platform">{comp1-full}</meta> -->
+<!-- <meta name="platform">{comp1-full} {comp1-version1}</meta>
+<meta name="platform">{comp2-full} {comp2-version1}</meta>
+<meta name="platform">{comp3-full} {comp3-version1}</meta> -->
+
+
+<!-- SUSE product listing for Google Analytics
+     - for a single SUSE product, use a single set of
+       'productname' and 'productnumber' tag pairs
+     - for multiple SUSE products, enclose a comma-delimited list
+       of product names and versions enclosed in a 'productname' tag pair
+     - do NOT use both forms
+       NOTE: value(s) are in SA_vars.adoc
+             and are layered upon variable spaces -->
+<!-- <productname>{productname}</productname>
+<productnumber>12 SP4, 12 SP5, 15, ...</productnumber> -->
+<!-- <productname>productname1 versionnumber, productname2 versionnumber, ...</productname> -->
+<productname>{mProductList}</productname>
+
+
+<!-- ## TechPartners ##
+        - additional context in search results
+        - Identify technical partners (businesses or organizations)
+          supplying components featured in the guide
+        - Replicate the pattern to identify additional partners
+          NOTE: value(s) are in SA_vars.adoc
+                and are layered upon variable spaces -->
+<meta name="techpartner">{mTechPartner}</meta>
+
+
+<!-- ## Author (mostly skipped in kubernetes/reference docs) ##
+	- Replicate author structure inside this authorgroup
+	  for additional authors
+	- Use "editor" and "othercredit" tag groups for additional
+          contributors
+<authorgroup>
   <author>
     <personname>
       <firstname></firstname>
@@ -51,26 +156,76 @@
   </author>
 </authorgroup> -->
 
-<!-- logo images
-     Duplicate mediaobject tag group and
-     reference additional logos as needed.
-     Place logo files under media directory tree.
--->
+
+<!-- ## Cover logo images ##
+        - Specify the image or images to use on the document cover
+
+        - NOTE: Two image objects are required to accommodate different
+                width requirements for HTML ('role="html"') and for
+                PDF ('role="fo"').
+                The default uses '5em' for for PDF and '152px' for HTML.
+
+        - The default logo (`common/images/src/svg/suse.svg`) is the
+          official SUSE chameleon with 'SUSE' printed to its right.
+        - The logo is designed for light backgrounds.
+        - When you run the setup script, a symbolic link to this image
+          file is created in your project's `media/src/svg` directory.
+        - Make no changes below if you wish to use this image.
+
+        - To display alternative logo (including an approved logo lock-up)
+          on the document cover:
+       - If the desired SVG image is located in `common/images/src/svg`,
+         create a symbolic link to it in your project's
+         `media/src/svg` directory.
+       - If you have a new SVG image, copy it to your project's
+         `media/src/svg` directory.
+         IMPORTANT: Trim extraneous whitespace from all sides of your image.
+       - Update 'fileref' in the tags below with the appropriate filename.
+
+        - It is possible to specify multiple, separate SVG logo images for the
+          cover logo by duplicating the `mediaobject` group and specifying
+          the appropriate files.
+          This is not preferred, as it can introduce alignment issues. -->
 <cover role="logos">
   <mediaobject>
     <imageobject role="fo">
-	    <imagedata fileref="{logo}" width="5em" align="center" valign="bottom"/>
+      <imagedata fileref="{logo}" width="5em" align="center" valign="bottom"/>
     </imageobject>
     <imageobject role="html">
-	    <imagedata fileref="{logo}" width="152px" align="center" valign="bottom"/>
+      <imagedata fileref="{logo}" width="152px" align="center" valign="bottom"/>
     </imageobject>
   </mediaobject>
 </cover>
 
-<!-- brief abstract/disclaimer for document
-     Update with an enticing summary.
+
+<!-- ## Revision History ##
+        - Provide a complete revision history in reverse chronological order
+          (most recent first).
+        - Each revision must include the data and a brief description,
+          enclosed in 'date' and 'revdescription' tag pairs.
+        - Define revision variables ('rev1-date', 'rev1-description',
+          'rev2-date', 'rev2-description', and so on) in the vars file.
 -->
-<abstract>
-  <para>{preface}</para>
-  <para> <emphasis role="strong">Disclaimer:</emphasis> {disclaimer} </para>
-</abstract>
+<revhistory xml:id="rh-art-{article-id}">
+  <revision>
+    <date>{rev2-date}</date>
+    <revdescription>
+      <para>{rev2-description}</para>
+    </revdescription>
+  </revision>
+  <revision>
+    <date>{rev1-date}</date>
+    <revdescription>
+      <para>{rev1-description}</para>
+    </revdescription>
+  </revision>
+</revhistory>
+
+
+<!-- FIXME : deprecated -->
+<!-- ## Date modified
+        - filter for the most recently changed or added documents
+          NOTE: This metadata tag will be deprecated in the
+                next template release. -->
+<!-- <meta name="updated">{revision-date}</meta> -->
+


### PR DESCRIPTION
Updated only the kubernetes reference files ... adoc/docinfo.xml and adoc/SA_vars.adoc and adoc/SA.adoc to just cover most all of the metadata variables. If this is accepted/usable, then I will likely do another PR to update the product versions across the kubernetes reference files and even add more content in this space as well.